### PR TITLE
Added include_network? methods for IPv4 and IPv6

### DIFF
--- a/lib/ipaddress/ipv4.rb
+++ b/lib/ipaddress/ipv4.rb
@@ -536,6 +536,26 @@ module IPAddress;
     def include?(oth)
       @prefix <= oth.prefix and network_u32 == (oth.to_u32 & @prefix.to_u32)
     end
+    
+    #
+    # Checks whether a subnet includes another subnet.
+    #
+    # ip = IPAddress("10.0.0.0/8")
+    #
+    # subnet = IPAddress("10.20.30.0/24")
+    #
+    # ip.include_network? subnet
+    #   #=> true
+    #
+    # ip.include_network? IPAddress("10.20.30.40/24")
+    #   #=> false
+    #
+    # ip.include_network? IPAddress("192.168.1.0/24")
+    #   #=> false
+    #
+    def include_network?(oth)
+      oth.network? && include?(oth)
+    end
 
     #
     # Checks if an IPv4 address objects belongs

--- a/lib/ipaddress/ipv6.rb
+++ b/lib/ipaddress/ipv6.rb
@@ -345,6 +345,29 @@ module IPAddress;
     def include?(oth)
       @prefix <= oth.prefix and network_u128 == self.class.new(oth.address+"/#@prefix").network_u128
     end
+    
+    #
+    # Checks whether a subnet includes another subnet.
+    #
+    # ip = IPAddress("2001:db8::/32")
+    #
+    # subnet = IPAddress("2001:db8:1::/48")
+    #
+    # ip.include_network? subnet
+    #   #=> true
+    #
+    # ip.include_network? IPAddress("2001:db8:1:abcd::/64")
+    #   #=> true
+    #
+    # ip.include_network? IPAddress("2001:db8:1:abcd::1234/64")
+    #   #=> false
+    #
+    # ip.include_network? IPAddress("2001:db9:1::/48")
+    #   #=> false
+    #
+    def include_network?(oth)
+      oth.network? && include?(oth)
+    end
 
     #
     # Compressed form of the IPv6 address


### PR DESCRIPTION
Added include_network? methods for IPv4 and IPv6 to check if a subnet includes a smaller subnet.
