### PR TITLE
network method for ipv6 address

### DIFF
--- a/lib/ipaddress/ipv6.rb
+++ b/lib/ipaddress/ipv6.rb
@@ -233,6 +233,20 @@ module IPAddress;
       to_u128 | @prefix.to_u128 == @prefix.to_u128
     end
 
+
+    #
+    # Returns a new IPv46object with the network number 
+    # for the given IP.
+    #
+    #   ip = IPAddress("fe80:0000:0000:0000:0000:0000:0000:282f/10""
+    #
+    #   ip.network.to_s
+    #     #=> "fe80::"
+    #
+    def network
+      self.class.parse_u128(network_u128, @prefix)
+    end
+
     #
     # Returns the 16-bits value specified by index
     #

--- a/test/ipaddress_test.rb
+++ b/test/ipaddress_test.rb
@@ -49,6 +49,16 @@ class IPAddressTest < Test::Unit::TestCase
     assert_equal true, IPAddress::valid_ipv4_netmask?("255.255.255.0")
     assert_equal false, IPAddress::valid_ipv4_netmask?("10.0.0.1")
   end
+  
+  def test_module_method_network?
+    assert_equal "199.59.148.80", IPAddress::IPv4.new("199.59.148.83/29").network.to_s
+    assert_equal "192.168.1.0", IPAddress::IPv4.new("192.168.1.99/24").network.to_s
+    
+    assert_equal "fe80::", IPAddress::IPv6.new("fe80:0000:0000:0000:0000:0000:0000:282f/10").network.to_s
+    assert_equal "fe80::", IPAddress::IPv6.new("fe80::282f/10").network.to_s
+  
+  
+  end
 
 end
 


### PR DESCRIPTION
hello,

I found out, that the network method is not available for the ipv6 address. I need this for a little project of mine, so I implemented it in your code. Would be nice to have it in the gem.

regards
Leif
