### PR TITLE
Remove superfluous (and erroneous) module includes from IPAddress::IPv6

### DIFF
--- a/lib/ipaddress/ipv6.rb
+++ b/lib/ipaddress/ipv6.rb
@@ -61,9 +61,6 @@ module IPAddress;
   class IPv6 
     
     include IPAddress
-    include Enumerable  
-    include Comparable                  
-
     
     #
     # Format string to pretty print IPv6 addresses


### PR DESCRIPTION
Don't include modules for which the mandatory primitives aren't implemented.

`IPAddress::IPv6` doesn't implement the `each` method (required for the `Enumerable` module) nor the `<=>` operator (required for the `Comparable` module), so it doesn't make sense to include these modules.

Including these modules makes the IPv6 instances respond to methods like `to_a` (from the `Enumerable` module) and `between?` (from the `Comparable` module), but these methods result in a NoMethodError exception (for the `each` and `<=>` methods respectively).

Example:

```
irb > IPAddress('::1').to_a
NoMethodError: undefined method `each' for #<IPAddress::IPv6:0x1016b3990>
    from (irb):1:in `to_a'
    from (irb):1

irb > IPAddress('::1').between? 1, 2
NoMethodError: undefined method `<=>' for #<IPAddress::IPv6:0x1016c5cd0>
    from (irb):1:in `between?'
    from (irb):1
```

From the standard Ruby rdoc:

```
ri Enumerable

The class must provide a method `each`, which yields successive members of the collection. 
```

and:

```
ri Comparable

The class must define the `<=>` operator, which compares the receiver against another object
```
