### PR TITLE
bugfix: do not consider /32 addresses as network adresses

### DIFF
--- a/lib/ipaddress/ipv4.rb
+++ b/lib/ipaddress/ipv4.rb
@@ -311,7 +311,7 @@ module IPAddress;
     #     #=> true
     #
     def network?
-      @u32 | @prefix.to_u32 == @prefix.to_u32
+      (@prefix < 32) && (@u32 | @prefix.to_u32 == @prefix.to_u32)
     end
 
     #

--- a/test/ipaddress/ipv4_test.rb
+++ b/test/ipaddress/ipv4_test.rb
@@ -144,6 +144,11 @@ class IPv4Test < Test::Unit::TestCase
     assert_equal true, @network.network?
     assert_equal false, @ip.network?
   end
+  
+  def test_one_address_network
+    network = @klass.new("172.16.10.1/32")
+    assert_equal false, network.network?
+  end
 
   def test_method_broadcast
     @broadcast.each do |addr,bcast|


### PR DESCRIPTION
I do not know how the network method should handle this case but network? should not return true.
