### PR TITLE
Added prefix parameter to IPv6.parse_data

### DIFF
--- a/lib/ipaddress/ipv6.rb
+++ b/lib/ipaddress/ipv6.rb
@@ -566,14 +566,13 @@ module IPAddress;
     #
     # With that data you can create a new IPv6 object:
     #
-    #   ip6 = IPAddress::IPv6::parse_data " \001\r\270\000\000\000\000\000\b\b\000 \fAz"
-    #   ip6.prefix = 64
+    #   ip6 = IPAddress::IPv6::parse_data " \001\r\270\000\000\000\000\000\b\b\000 \fAz", 64
     #
     #   ip6.to_s
     #     #=> "2001:db8::8:800:200c:417a/64"
     #
-    def self.parse_data(str)
-      self.new(IN6FORMAT % str.unpack("n8"))
+    def self.parse_data(str, prefix=128)
+      return self.new(IN6FORMAT % str.unpack("n8") + '/' + prefix.to_s)
     end
 
     #

--- a/test/ipaddress/ipv6_test.rb
+++ b/test/ipaddress/ipv6_test.rb
@@ -279,6 +279,12 @@ class IPv6Test < Test::Unit::TestCase
     assert_equal "2001:db8::8:800:200c:417a/128", ip.to_string
   end
 
+  def test_classmethod_parse_data_with_prefix
+    str = " \001\r\270\000\000\000\000\000\b\b\000 \fAz"
+    ip = @klass.parse_data str, 64
+    assert_equal "2001:db8::8:800:200c:417a/64", ip.to_string
+  end
+
   def test_classhmethod_parse_u128
     @valid_ipv6.each do |ip,num|
       assert_equal @klass.new(ip).to_s, @klass.parse_u128(num).to_s


### PR DESCRIPTION
Hi

IPv6.parse_data is the only parse method which doesn't have a prefix parameter. I added it to make to improve consistency.

Cheers
Hannes
