### PR TITLE
Removed some warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,6 +26,7 @@ Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test'
   test.pattern = 'test/**/*_test.rb'
   test.verbose = true
+  test.warning = true
 end
 
 begin

--- a/lib/ipaddress/prefix.rb
+++ b/lib/ipaddress/prefix.rb
@@ -78,7 +78,7 @@ module IPAddress
       end
     end
     
-   end # class Prefix
+  end # class Prefix
 
 
   class Prefix32 < Prefix

--- a/test/ipaddress/ipv4_test.rb
+++ b/test/ipaddress/ipv4_test.rb
@@ -67,7 +67,7 @@ class IPv4Test < Test::Unit::TestCase
       assert_instance_of @klass, ip
     end
     assert_instance_of IPAddress::Prefix32, @ip.prefix
-    assert_raise (ArgumentError) do
+    assert_raise(ArgumentError) do
       @klass.new 
     end
     assert_nothing_raised do
@@ -79,7 +79,7 @@ class IPv4Test < Test::Unit::TestCase
     @invalid_ipv4.each do |i|
       assert_raise(ArgumentError) {@klass.new(i)}
     end
-    assert_raise (ArgumentError) {@klass.new("10.0.0.0/asd")}
+    assert_raise(ArgumentError) {@klass.new("10.0.0.0/asd")}
   end
 
   def test_initialize_without_prefix

--- a/test/ipaddress/prefix_test.rb
+++ b/test/ipaddress/prefix_test.rb
@@ -89,7 +89,7 @@ class Prefix32Test < Test::Unit::TestCase
   end
 
   def test_initialize
-    assert_raise (ArgumentError) do
+    assert_raise(ArgumentError) do
       @klass.new 33
     end
     assert_nothing_raised do
@@ -135,7 +135,7 @@ class Prefix128Test < Test::Unit::TestCase
   end
 
   def test_initialize
-    assert_raise (ArgumentError) do
+    assert_raise(ArgumentError) do
       @klass.new 129
     end
     assert_nothing_raised do


### PR DESCRIPTION
They remove below ruby's warnings.
I have tested on MRI 1.9.3
- warning: mismatched indentations
- warning: (...) interpreted as grouped expression (in test)
