### PR TITLE
Add 'broadcast' method to IPAddress::IPv6

### DIFF
--- a/lib/ipaddress/ipv6.rb
+++ b/lib/ipaddress/ipv6.rb
@@ -496,6 +496,18 @@ module IPAddress;
     end
     
     #
+    # Returns the broadcast address for the given IP.
+    #
+    # ip = IPAddress("2001:db8::8:800:200c:417a/64")
+    #
+    # ip.broadcast.to_s
+    # #=> "2001:db8::ffff:ffff:ffff:ffff"
+    #
+    def broadcast
+      self.class.parse_u128(broadcast_u128, @prefix)
+    end
+    
+    #
     # Expands an IPv6 address in the canocical form
     #
     #   IPAddress::IPv6.expand "2001:0DB8:0:CD30::"


### PR DESCRIPTION
`broadcast` method was missing in IPAddress::IPv6.

I needed it because I store networks broadcast address in DB (this way I can find network hosts by searching ones between network and broadcast addresses).
