### PR TITLE
Raise ArgumentError if IP is nil

### DIFF
--- a/lib/ipaddress/ipv4.rb
+++ b/lib/ipaddress/ipv4.rb
@@ -1,9 +1,9 @@
 require 'ipaddress/prefix'
 
-module IPAddress; 
-  # 
+module IPAddress;
+  #
   # =Name
-  # 
+  #
   # IPAddress::IPv4 - IP version 4 address manipulation library
   #
   # =Synopsis
@@ -11,19 +11,19 @@ module IPAddress;
   #    require 'ipaddress'
   #
   # =Description
-  # 
-  # Class IPAddress::IPv4 is used to handle IPv4 type addresses. 
+  #
+  # Class IPAddress::IPv4 is used to handle IPv4 type addresses.
   #
   class IPv4
-    
+
     include IPAddress
-    include Enumerable  
-    include Comparable                  
-    
+    include Enumerable
+    include Comparable
+
     #
     # This Hash contains the prefix values for Classful networks
     #
-    # Note that classes C, D and E will all have a default 
+    # Note that classes C, D and E will all have a default
     # prefix of /24 or 255.255.255.0
     #
     CLASSFUL = {
@@ -36,44 +36,45 @@ module IPAddress;
     # Regular expression to match an IPv4 address
     #
     REGEXP = Regexp.new(/((25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)\.){3}(25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)/)
-    
+
     #
     # Creates a new IPv4 address object.
     #
     # An IPv4 address can be expressed in any of the following forms:
-    # 
+    #
     # * "10.1.1.1/24": ip +address+ and +prefix+. This is the common and
     # suggested way to create an object                  .
     # * "10.1.1.1/255.255.255.0": ip +address+ and +netmask+. Although
     # convenient sometimes, this format is less clear than the previous
-    # one.             
+    # one.
     # * "10.1.1.1": if the address alone is specified, the prefix will be
-    # set as default 32, also known as the host prefix    
+    # set as default 32, also known as the host prefix
     #
     # Examples:
     #
     #   # These two are the same
     #   ip = IPAddress::IPv4.new("10.0.0.1/24")
     #   ip = IPAddress("10.0.0.1/24")
-    #   
+    #
     #   # These two are the same
     #   IPAddress::IPv4.new "10.0.0.1/8"
     #   IPAddress::IPv4.new "10.0.0.1/255.0.0.0"
     #
     def initialize(str)
+      raise ArgumentError, "Nil IP" unless str
       ip, netmask = str.split("/")
-      
+
       # Check the ip and remove white space
       if IPAddress.valid_ipv4?(ip)
         @address = ip.strip
       else
         raise ArgumentError, "Invalid IP #{ip.inspect}"
       end
-      
+
       # Check the netmask
       if netmask  # netmask is defined
         netmask.strip!
-        if netmask =~ /^\d{1,2}$/  # netmask in cidr format 
+        if netmask =~ /^\d{1,2}$/  # netmask in cidr format
           @prefix = Prefix32.new(netmask.to_i)
         elsif IPAddress.valid_ipv4_netmask?(netmask)  # netmask in IP format
           @prefix = Prefix32.parse_netmask(netmask)
@@ -88,7 +89,7 @@ module IPAddress;
       @octets = @address.split(".").map{|i| i.to_i}
       # 32 bits interger containing the address
       @u32 = (@octets[0]<< 24) + (@octets[1]<< 16) + (@octets[2]<< 8) + (@octets[3])
-      
+
     end # def initialize
 
     #
@@ -132,7 +133,7 @@ module IPAddress;
     #
     #   puts ip
     #     #=> 172.16.100.4/16
-    #   
+    #
     #   ip.prefix = 22
     #
     #   puts ip
@@ -142,7 +143,7 @@ module IPAddress;
       @prefix = Prefix32.new(num)
     end
 
-    # 
+    #
     # Returns the address as an array of decimal values
     #
     #   ip = IPAddress("172.16.100.4")
@@ -153,9 +154,9 @@ module IPAddress;
     def octets
       @octets
     end
-    
+
     #
-    # Returns a string with the address portion of 
+    # Returns a string with the address portion of
     # the IPv4 object
     #
     #   ip = IPAddress("172.16.100.4/22")
@@ -180,7 +181,7 @@ module IPAddress;
       "#@address/#@prefix"
     end
 
-    # 
+    #
     # Returns the prefix as a string in IP format
     #
     #   ip = IPAddress("172.16.100.4/22")
@@ -193,7 +194,7 @@ module IPAddress;
     end
 
     #
-    # Like IPv4#prefix=, this method allow you to 
+    # Like IPv4#prefix=, this method allow you to
     # change the prefix / netmask of an IP address
     # object.
     #
@@ -216,8 +217,8 @@ module IPAddress;
     # 32 bits integer format.
     #
     # This method is identical to the C function
-    # inet_pton to create a 32 bits address family 
-    # structure. 
+    # inet_pton to create a 32 bits address family
+    # structure.
     #
     #   ip = IPAddress("10.0.0.0/8")
     #
@@ -229,7 +230,7 @@ module IPAddress;
     end
     alias_method :to_i, :u32
     alias_method :to_u32, :u32
-    
+
     #
     # Returns the address portion of an IPv4 object
     # in a network byte order format.
@@ -244,8 +245,8 @@ module IPAddress;
     #
     #   a = Socket.open(params) # socket details here
     #   ip = IPAddress("10.1.1.0/24")
-    #   binary_data = ["Address: "].pack("a*") + ip.data 
-    #   
+    #   binary_data = ["Address: "].pack("a*") + ip.data
+    #
     #   # Send binary data
     #   a.puts binary_data
     #
@@ -271,7 +272,7 @@ module IPAddress;
       @octets[index]
     end
     alias_method :octet, :[]
-    
+
     #
     # Returns the address portion of an IP in binary format,
     # as a string containing a sequence of 0 and 1
@@ -296,7 +297,7 @@ module IPAddress;
     def broadcast
       self.class.parse_u32(broadcast_u32, @prefix)
     end
-    
+
     #
     # Checks if the IP address is actually a network
     #
@@ -304,7 +305,7 @@ module IPAddress;
     #
     #   ip.network?
     #     #=> false
-    # 
+    #
     #   ip = IPAddress("172.16.10.64/26")
     #
     #   ip.network?
@@ -315,7 +316,7 @@ module IPAddress;
     end
 
     #
-    # Returns a new IPv4 object with the network number 
+    # Returns a new IPv4 object with the network number
     # for the given IP.
     #
     #   ip = IPAddress("172.16.10.64/24")
@@ -330,7 +331,7 @@ module IPAddress;
     #
     # Returns a new IPv4 object with the
     # first host IP address in the range.
-    # 
+    #
     # Example: given the 192.168.100.0/24 network, the first
     # host IP address is 192.168.100.1.
     #
@@ -352,10 +353,10 @@ module IPAddress;
     end
 
     #
-    # Like its sibling method IPv4#first, this method 
-    # returns a new IPv4 object with the 
+    # Like its sibling method IPv4#first, this method
+    # returns a new IPv4 object with the
     # last host IP address in the range.
-    # 
+    #
     # Example: given the 192.168.100.0/24 network, the last
     # host IP address is 192.168.100.254
     #
@@ -429,15 +430,15 @@ module IPAddress;
     # Spaceship operator to compare IPv4 objects
     #
     # Comparing IPv4 addresses is useful to ordinate
-    # them into lists that match our intuitive 
+    # them into lists that match our intuitive
     # perception of ordered IP addresses.
-    # 
+    #
     # The first comparison criteria is the u32 value.
-    # For example, 10.100.100.1 will be considered 
+    # For example, 10.100.100.1 will be considered
     # to be less than 172.16.0.1, because, in a ordered list,
     # we expect 10.100.100.1 to come before 172.16.0.1.
     #
-    # The second criteria, in case two IPv4 objects 
+    # The second criteria, in case two IPv4 objects
     # have identical addresses, is the prefix. An higher
     # prefix will be considered greater than a lower
     # prefix. This is because we expect to see
@@ -458,10 +459,10 @@ module IPAddress;
     #     #=> ["10.100.100.1/8","10.100.100.1/16","172.16.0.1/16"]
     #
     def <=>(oth)
-      return prefix <=> oth.prefix if to_u32 == oth.to_u32  
+      return prefix <=> oth.prefix if to_u32 == oth.to_u32
       to_u32 <=> oth.to_u32
     end
-    
+
     #
     # Returns the number of IP addresses included
     # in the network. It also counts the network
@@ -479,7 +480,7 @@ module IPAddress;
     #
     # Returns an array with the IP addresses of
     # all the hosts in the network.
-    # 
+    #
     #   ip = IPAddress("10.0.0.1/29")
     #
     #   ip.hosts.map {|i| i.address}
@@ -493,7 +494,7 @@ module IPAddress;
     def hosts
       to_a[1..-2]
     end
-    
+
     #
     # Returns the network number in Unsigned 32bits format
     #
@@ -538,7 +539,7 @@ module IPAddress;
     end
 
     #
-    # Checks whether a subnet includes all the 
+    # Checks whether a subnet includes all the
     # given IPv4 objects.
     #
     #   ip = IPAddress("192.168.10.100/24")
@@ -552,7 +553,7 @@ module IPAddress;
     def include_all?(*others)
       others.all? {|oth| include?(oth)}
     end
-    
+
     #
     # Checks if an IPv4 address objects belongs
     # to a private network RFC1918
@@ -582,7 +583,7 @@ module IPAddress;
       @octets.reverse.join(".") + ".in-addr.arpa"
     end
     alias_method :arpa, :reverse
-    
+
     #
     # Splits a network into different subnets
     #
@@ -591,7 +592,7 @@ module IPAddress;
     # method will calculate the network from the IP and then
     # subnet it.
     #
-    # If +subnets+ is an power of two number, the resulting 
+    # If +subnets+ is an power of two number, the resulting
     # networks will be divided evenly from the supernet.
     #
     #   network = IPAddress("172.16.10.0/24")
@@ -602,7 +603,7 @@ module IPAddress;
     #          "172.16.10.128/26",
     #          "172.16.10.192/26"]
     #
-    # If +num+ is any other number, the supernet will be 
+    # If +num+ is any other number, the supernet will be
     # divided into some networks with a even number of hosts and
     # other networks with the remaining addresses.
     #
@@ -617,7 +618,7 @@ module IPAddress;
     #
     def split(subnets=2)
       unless (1..(2**@prefix.host_prefix)).include? subnets
-        raise ArgumentError, "Value #{subnets} out of range" 
+        raise ArgumentError, "Value #{subnets} out of range"
       end
       networks = subnet(newprefix(subnets))
       until networks.size == subnets
@@ -658,7 +659,7 @@ module IPAddress;
     end
 
     #
-    # This method implements the subnetting function 
+    # This method implements the subnetting function
     # similar to the one described in RFC3531.
     #
     # By specifying a new prefix, the method calculates
@@ -673,7 +674,7 @@ module IPAddress;
     # we can calculate the subnets with a /26 prefix
     #
     #   ip.subnets(26).map{&:to_string)
-    #     #=> ["172.16.10.0/26", "172.16.10.64/26", 
+    #     #=> ["172.16.10.0/26", "172.16.10.64/26",
     #          "172.16.10.128/26", "172.16.10.192/26"]
     #
     # The resulting number of subnets will of course always be
@@ -691,7 +692,7 @@ module IPAddress;
     #
     # Returns the difference between two IP addresses
     # in unsigned int 32 bits format
-    #  
+    #
     # Example:
     #
     #   ip1 = IPAddress("172.16.10.0/24")
@@ -705,8 +706,8 @@ module IPAddress;
     end
 
     #
-    # Returns a new IPv4 object which is the result 
-    # of the summarization, if possible, of the two 
+    # Returns a new IPv4 object which is the result
+    # of the summarization, if possible, of the two
     # objects
     #
     # Example:
@@ -731,12 +732,12 @@ module IPAddress;
     end
 
     #
-    # Checks whether the ip address belongs to a 
+    # Checks whether the ip address belongs to a
     # RFC 791 CLASS A network, no matter
     # what the subnet mask is.
     #
     # Example:
-    # 
+    #
     #   ip = IPAddress("10.0.0.1/24")
     #
     #   ip.a?
@@ -745,7 +746,7 @@ module IPAddress;
     def a?
       CLASSFUL.key(8) === bits
     end
-    
+
     #
     # Checks whether the ip address belongs to a
     # RFC 791 CLASS B network, no matter
@@ -781,7 +782,7 @@ module IPAddress;
     #
     # Return the ip address in a format compatible
     # with the IPv6 Mapped IPv4 addresses
-    # 
+    #
     # Example:
     #
     #   ip = IPAddress("172.16.10.1/24")
@@ -817,10 +818,10 @@ module IPAddress;
     #
     # Creates a new IPv4 object from binary data,
     # like the one you get from a network stream.
-    # 
+    #
     # For example, on a network stream the IP 172.16.0.1
     # is represented with the binary "\254\020\n\001".
-    # 
+    #
     #   ip = IPAddress::IPv4::parse_data "\254\020\n\001"
     #   ip.prefix = 24
     #
@@ -832,7 +833,7 @@ module IPAddress;
     end
 
     #
-    # Extract an IPv4 address from a string and 
+    # Extract an IPv4 address from a string and
     # returns a new object
     #
     # Example:
@@ -846,7 +847,7 @@ module IPAddress;
     def self.extract(str)
       self.new REGEXP.match(str).to_s
     end
-    
+
     #
     # Summarization (or aggregation) is the process when two or more
     # networks are taken together to check if a supernet, including all
@@ -877,7 +878,7 @@ module IPAddress;
     #
     # We note how the network "172.16.10.0/23" includes all the addresses
     # specified in the above networks, and (more important) includes
-    # ONLY those addresses. 
+    # ONLY those addresses.
     #
     # If we summarized +ip1+ and +ip2+ with the following network:
     #
@@ -897,7 +898,7 @@ module IPAddress;
     #   ip4 = IPAddress("10.0.3.1/24")
     #
     #   IPAddress::IPv4::summarize(ip1,ip2,ip3,ip4).to_string
-    #     #=> "10.0.0.0/22", 
+    #     #=> "10.0.0.0/22",
     #
     # But the following networks can't be summarized in a single network:
     #
@@ -912,7 +913,7 @@ module IPAddress;
     def self.summarize(*args)
       # one network? no need to summarize
       return [args.first.network] if args.size == 1
-      
+
       i = 0
       result = args.dup.sort.map{|ip| ip.network}
       while i < result.size-1
@@ -920,7 +921,7 @@ module IPAddress;
         result[i..i+1] = sum.first if sum.size == 1
         i += 1
       end
-      
+
       result.flatten!
       if result.size == args.size
         # nothing more to summarize
@@ -932,10 +933,10 @@ module IPAddress;
     end
 
     #
-    # Creates a new IPv4 address object by parsing the 
+    # Creates a new IPv4 address object by parsing the
     # address in a classful way.
     #
-    # Classful addresses have a fixed netmask based on the 
+    # Classful addresses have a fixed netmask based on the
     # class they belong to:
     #
     # * Class A, from 0.0.0.0 to 127.255.255.255
@@ -946,7 +947,7 @@ module IPAddress;
     #
     #   ip = IPAddress::IPv4.parse_classful "10.0.0.1"
     #
-    #   ip.netmask 
+    #   ip.netmask
     #     #=> "255.0.0.0"
     #   ip.a?
     #     #=> true
@@ -972,11 +973,11 @@ module IPAddress;
     def newprefix(num)
       num.upto(32) do |i|
         if (a = Math::log2(i).to_i) == Math::log2(i)
-          return @prefix + a 
+          return @prefix + a
         end
       end
     end
-    
+
     def sum_first_found(arr)
       dup = arr.dup.reverse
       dup.each_with_index do |obj,i|

--- a/lib/ipaddress/ipv6.rb
+++ b/lib/ipaddress/ipv6.rb
@@ -1,9 +1,9 @@
 require 'ipaddress/prefix'
 
-module IPAddress; 
-  # 
+module IPAddress;
+  #
   # =Name
-  # 
+  #
   # IPAddress::IPv6 - IP version 6 address manipulation library
   #
   # =Synopsis
@@ -11,8 +11,8 @@ module IPAddress;
   #    require 'ipaddress'
   #
   # =Description
-  # 
-  # Class IPAddress::IPv6 is used to handle IPv6 type addresses. 
+  #
+  # Class IPAddress::IPv6 is used to handle IPv6 type addresses.
   #
   # == IPv6 addresses
   #
@@ -58,25 +58,25 @@ module IPAddress;
   # portion.
   #
   #
-  class IPv6 
-    
-    include IPAddress
-    include Enumerable  
-    include Comparable                  
+  class IPv6
 
-    
+    include IPAddress
+    include Enumerable
+    include Comparable
+
+
     #
     # Format string to pretty print IPv6 addresses
     #
     IN6FORMAT = ("%.4x:"*8).chop
-    
+
     #
     # Creates a new IPv6 address object.
     #
     # An IPv6 address can be expressed in any of the following forms:
-    # 
+    #
     # * "2001:0db8:0000:0000:0008:0800:200C:417A": IPv6 address with no compression
-    # * "2001:db8:0:0:8:800:200C:417A": IPv6 address with leading zeros compression 
+    # * "2001:db8:0:0:8:800:200C:417A": IPv6 address with leading zeros compression
     # * "2001:db8::8:800:200C:417A": IPv6 address with full compression
     #
     # In all these 3 cases, a new IPv6 address object will be created, using the default
@@ -87,12 +87,13 @@ module IPAddress;
     #   ip6 = IPAddress "2001:db8::8:800:200c:417a/64"
     #
     def initialize(str)
+      raise ArgumentError, "Nil IP" unless str
       ip, netmask = str.split("/")
 
       if str =~ /:.+\./
         raise ArgumentError, "Please use #{self.class}::Mapped for IPv4 mapped addresses"
       end
-      
+
       if IPAddress.valid_ipv6?(ip)
         @groups = self.class.groups(ip)
         @address = IN6FORMAT % @groups
@@ -118,7 +119,7 @@ module IPAddress;
     end
 
     #
-    # Returns an array with the 16 bits groups in decimal 
+    # Returns an array with the 16 bits groups in decimal
     # format:
     #
     #   ip6 = IPAddress "2001:db8::8:800:200c:417a/64"
@@ -130,7 +131,7 @@ module IPAddress;
       @groups
     end
 
-    # 
+    #
     # Returns an instance of the prefix object
     #
     #   ip6 = IPAddress "2001:db8::8:800:200c:417a/64"
@@ -163,8 +164,8 @@ module IPAddress;
       @prefix = Prefix128.new(num)
     end
 
-    # 
-    # Unlike its counterpart IPv6#to_string method, IPv6#to_string_uncompressed 
+    #
+    # Unlike its counterpart IPv6#to_string method, IPv6#to_string_uncompressed
     # returns the whole IPv6 address and prefix in an uncompressed form
     #
     #   ip6 = IPAddress "2001:db8::8:800:200c:417a/64"
@@ -252,8 +253,8 @@ module IPAddress;
     end
     alias_method :group, :[]
 
-    # 
-    # Returns a Base16 number representing the IPv6 
+    #
+    # Returns a Base16 number representing the IPv6
     # address
     #
     #   ip6 = IPAddress "2001:db8::8:800:200c:417a/64"
@@ -288,7 +289,7 @@ module IPAddress;
     end
 
     #
-    # Returns an array of the 16 bits groups in hexdecimal 
+    # Returns an array of the 16 bits groups in hexdecimal
     # format:
     #
     #   ip6 = IPAddress "2001:db8::8:800:200c:417a/64"
@@ -305,9 +306,9 @@ module IPAddress;
     #
     # Returns the IPv6 address in a DNS reverse lookup
     # string, as per RFC3172 and RFC2874.
-    #   
+    #
     #   ip6 = IPAddress "3ffe:505:2::f"
-    #   
+    #
     #   ip6.reverse
     #     #=> "f.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.2.0.0.0.5.0.5.0.e.f.f.3.ip6.arpa"
     #
@@ -337,7 +338,7 @@ module IPAddress;
     #     #=> 42540766411282592875350729025363378175
     #
     # Please note that there is no Broadcast concept in IPv6
-    # addresses as in IPv4 addresses, and this method is just 
+    # addresses as in IPv4 addresses, and this method is just
     # an helper to other functions.
     #
     def broadcast_u128
@@ -388,27 +389,27 @@ module IPAddress;
       @compressed
     end
 
-    # 
+    #
     # Returns true if the address is an unspecified address
-    # 
+    #
     # See IPAddress::IPv6::Unspecified for more information
     #
     def unspecified?
       @prefix == 128 and @compressed == "::"
     end
 
-    # 
+    #
     # Returns true if the address is a loopback address
-    # 
+    #
     # See IPAddress::IPv6::Loopback for more information
     #
     def loopback?
       @prefix == 128 and @compressed == "::1"
     end
 
-    # 
+    #
     # Returns true if the address is a mapped address
-    # 
+    #
     # See IPAddress::IPv6::Mapped for more information
     #
     def mapped?
@@ -436,7 +437,7 @@ module IPAddress;
     #     #=> "2001:db8::6"
     #     #=> "2001:db8::7"
     #
-    # WARNING: if the host portion is very large, this method 
+    # WARNING: if the host portion is very large, this method
     # can be very slow and possibly hang your system!
     #
     def each
@@ -449,15 +450,15 @@ module IPAddress;
     # Spaceship operator to compare IPv6 objects
     #
     # Comparing IPv6 addresses is useful to ordinate
-    # them into lists that match our intuitive 
+    # them into lists that match our intuitive
     # perception of ordered IP addresses.
-    # 
+    #
     # The first comparison criteria is the u128 value.
-    # For example, 2001:db8:1::1 will be considered 
+    # For example, 2001:db8:1::1 will be considered
     # to be less than 2001:db8:2::1, because, in a ordered list,
     # we expect 2001:db8:1::1 to come before 2001:db8:2::1.
     #
-    # The second criteria, in case two IPv6 objects 
+    # The second criteria, in case two IPv6 objects
     # have identical addresses, is the prefix. An higher
     # prefix will be considered greater than a lower
     # prefix. This is because we expect to see
@@ -478,7 +479,7 @@ module IPAddress;
     #     #=> ["2001:db8:1::1/64","2001:db8:1::1/65","2001:db8:2::1/64"]
     #
     def <=>(oth)
-      return prefix <=> oth.prefix if to_u128 == oth.to_u128  
+      return prefix <=> oth.prefix if to_u128 == oth.to_u128
       to_u128 <=> oth.to_u128
     end
 
@@ -488,13 +489,13 @@ module IPAddress;
     #
     #   ip6 = IPAddress("2001:db8::8:800:200c:417a")
     #
-    #   ip6.bits 
+    #   ip6.bits
     #     #=> "0010000000000001000011011011100000 [...] "
     #
     def bits
       data.unpack("B*").first
     end
-    
+
     #
     # Expands an IPv6 address in the canocical form
     #
@@ -515,23 +516,23 @@ module IPAddress;
       self.new(str).compressed
     end
 
-    # 
+    #
     # Literal version of the IPv6 address
     #
     #   ip6 = IPAddress "2001:db8::8:800:200c:417a/64"
     #
     #   ip6.literal
     #     #=> "2001-0db8-0000-0000-0008-0800-200c-417a.ipv6-literal.net"
-    # 
+    #
     def literal
       @address.gsub(":","-") + ".ipv6-literal.net"
     end
 
     #
-    # Returns a new IPv6 object with the network number 
+    # Returns a new IPv6 object with the network number
     # for the given IP.
     #
-    #   ip = IPAddress "2001:db8:1:1:1:1:1:1/32" 
+    #   ip = IPAddress "2001:db8:1:1:1:1:1:1/32"
     #
     #   ip.network.to_string
     #     #=> "2001:db8::/32"
@@ -555,9 +556,9 @@ module IPAddress;
     #
     # Creates a new IPv6 object from binary data,
     # like the one you get from a network stream.
-    # 
-    # For example, on a network stream the IP 
-    # 
+    #
+    # For example, on a network stream the IP
+    #
     #  "2001:db8::8:800:200c:417a"
     #
     # is represented with the binary data
@@ -618,7 +619,7 @@ module IPAddress;
     def self.parse_hex(hex, prefix=128)
       self.parse_u128(hex.hex, prefix)
     end
-    
+
     private
 
     def compress_address
@@ -635,7 +636,7 @@ module IPAddress;
       end
       str.sub(/:{3,}/, '::')
     end
-    
+
   end # class IPv6
 
   #
@@ -694,7 +695,7 @@ module IPAddress;
       @groups = Array.new(8,0)
       @prefix = Prefix128.new(128)
       @compressed = compress_address
-    end 
+    end
   end # class IPv6::Unspecified
 
   #
@@ -744,7 +745,7 @@ module IPAddress;
     #
     def initialize
       @address = ("0000:"*7)+"0001"
-      @groups = Array.new(7,0).push(1) 
+      @groups = Array.new(7,0).push(1)
       @prefix = Prefix128.new(128)
       @compressed = compress_address
     end
@@ -823,7 +824,7 @@ module IPAddress;
     #   ipv6.ipv4.class
     #     #=> IPAddress::IPv4
     #
-    # An IPv6 IPv4-mapped address can also be created using the 
+    # An IPv6 IPv4-mapped address can also be created using the
     # IPv6 only format of the address:
     #
     #   ip6 = IPAddress::IPv6::Mapped.new "::0d01:4403"
@@ -842,8 +843,8 @@ module IPAddress;
       super("::ffff:#{@ipv4.to_ipv6}/#{netmask}")
     end
 
-    # 
-    # Similar to IPv6#to_s, but prints out the IPv4 address 
+    #
+    # Similar to IPv6#to_s, but prints out the IPv4 address
     # in dotted decimal format
     #
     #   ip6 = IPAddress "::ffff:172.16.10.1/128"
@@ -855,8 +856,8 @@ module IPAddress;
       "::ffff:#{@ipv4.address}"
     end
 
-    # 
-    # Similar to IPv6#to_string, but prints out the IPv4 address 
+    #
+    # Similar to IPv6#to_string, but prints out the IPv4 address
     # in dotted decimal format
     #
     #

--- a/test/ipaddress/ipv4_test.rb
+++ b/test/ipaddress/ipv4_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
- 
+
 class IPv4Test < Test::Unit::TestCase
 
   def setup
@@ -11,7 +11,7 @@ class IPv4Test < Test::Unit::TestCase
       "10.0.0.1" => ["10.0.0.1", 32],
       "10.0.0.1/24" => ["10.0.0.1", 24],
       "10.0.0.1/255.255.255.0" => ["10.0.0.1", 24]}
-    
+
     @invalid_ipv4 = ["10.0.0.256",
                      "10.0.0.0.0",
                      "10.0.0",
@@ -28,22 +28,22 @@ class IPv4Test < Test::Unit::TestCase
       "192.168.0.0/24"   => "255.255.255.0",
       "192.168.100.4/30" => "255.255.255.252"}
 
-    @decimal_values ={      
+    @decimal_values ={
       "0.0.0.0/0"        => 0,
       "10.0.0.0/8"       => 167772160,
       "172.16.0.0/16"    => 2886729728,
       "192.168.0.0/24"   => 3232235520,
       "192.168.100.4/30" => 3232261124}
-    
+
     @ip = @klass.new("172.16.10.1/24")
     @network = @klass.new("172.16.10.0/24")
-    
+
     @broadcast = {
       "10.0.0.0/8"       => "10.255.255.255/8",
       "172.16.0.0/16"    => "172.16.255.255/16",
       "192.168.0.0/24"   => "192.168.0.255/24",
       "192.168.100.4/30" => "192.168.100.7/30"}
-    
+
     @networks = {
       "10.5.4.3/8"       => "10.0.0.0/8",
       "172.16.5.4/16"    => "172.16.0.0/16",
@@ -58,7 +58,7 @@ class IPv4Test < Test::Unit::TestCase
       "10.1.1.1"  => 8,
       "150.1.1.1" => 16,
       "200.1.1.1" => 24 }
-    
+
   end
 
   def test_initialize
@@ -68,7 +68,7 @@ class IPv4Test < Test::Unit::TestCase
     end
     assert_instance_of IPAddress::Prefix32, @ip.prefix
     assert_raise (ArgumentError) do
-      @klass.new 
+      @klass.new
     end
     assert_nothing_raised do
       @klass.new "10.0.0.0/8"
@@ -79,6 +79,7 @@ class IPv4Test < Test::Unit::TestCase
     @invalid_ipv4.each do |i|
       assert_raise(ArgumentError) {@klass.new(i)}
     end
+    assert_raise (ArgumentError) {@klass.new(nil)}
     assert_raise (ArgumentError) {@klass.new("10.0.0.0/asd")}
   end
 
@@ -103,7 +104,7 @@ class IPv4Test < Test::Unit::TestCase
     ip = @klass.new("10.1.2.3/8")
     assert_equal ip.octets, [10,1,2,3]
   end
-  
+
   def test_initialize_should_require_ip
     assert_raise(ArgumentError) { @klass.new }
   end
@@ -115,7 +116,7 @@ class IPv4Test < Test::Unit::TestCase
       assert_equal "\xAC\x10\n\x01".b, @ip.data
     end
   end
-  
+
   def test_method_to_string
     @valid_ipv4.each do |arg,attr|
       ip = @klass.new(arg)
@@ -156,7 +157,7 @@ class IPv4Test < Test::Unit::TestCase
       assert_equal bcast, ip.broadcast.to_string
     end
   end
-  
+
   def test_method_network
     @networks.each do |addr,net|
       ip = @klass.new addr
@@ -187,7 +188,7 @@ class IPv4Test < Test::Unit::TestCase
     assert_instance_of @klass, ip.last
     assert_equal  "192.168.100.254", ip.last.to_s
   end
-  
+
   def test_method_each_host
     ip = @klass.new("10.0.0.1/29")
     arr = []
@@ -222,7 +223,7 @@ class IPv4Test < Test::Unit::TestCase
   def test_method_network_u32
     assert_equal 2886732288, @ip.network_u32
   end
-  
+
   def test_method_broadcast_u32
     assert_equal 2886732543, @ip.broadcast_u32
   end
@@ -241,13 +242,13 @@ class IPv4Test < Test::Unit::TestCase
     assert_equal false, ip.include?(@klass.new("5.5.5.5/32"))
     assert_equal false, ip.include?(@klass.new("11.0.0.0/8"))
     ip = @klass.new("13.13.0.0/13")
-    assert_equal false, ip.include?(@klass.new("13.16.0.0/32"))    
+    assert_equal false, ip.include?(@klass.new("13.16.0.0/32"))
   end
 
   def test_method_include_all?
     ip = @klass.new("192.168.10.100/24")
     addr1 = @klass.new("192.168.10.102/24")
-    addr2 = @klass.new("192.168.10.103/24")    
+    addr2 = @klass.new("192.168.10.103/24")
     assert_equal true, ip.include_all?(addr1,addr2)
     assert_equal false, ip.include_all?(addr1, @klass.new("13.16.0.0/32"))
   end
@@ -255,11 +256,11 @@ class IPv4Test < Test::Unit::TestCase
   def test_method_ipv4?
     assert_equal true, @ip.ipv4?
   end
-  
+
   def test_method_ipv6?
     assert_equal false, @ip.ipv6?
   end
-    
+
   def test_method_private?
     assert_equal true, @klass.new("192.168.10.50/24").private?
     assert_equal true, @klass.new("192.168.10.50/16").private?
@@ -303,11 +304,11 @@ class IPv4Test < Test::Unit::TestCase
   def test_method_to_ipv6
     assert_equal "ac10:0a01", @ip.to_ipv6
   end
-  
+
   def test_method_reverse
     assert_equal "1.10.16.172.in-addr.arpa", @ip.reverse
   end
-  
+
   def test_method_compare
     ip1 = @klass.new("10.1.1.1/8")
     ip2 = @klass.new("10.1.1.1/16")
@@ -317,7 +318,7 @@ class IPv4Test < Test::Unit::TestCase
     # ip2 should be greater than ip1
     assert_equal true, ip1 < ip2
     assert_equal false, ip1 > ip2
-    assert_equal false, ip2 < ip1        
+    assert_equal false, ip2 < ip1
     # ip2 should be less than ip3
     assert_equal true, ip2 < ip3
     assert_equal false, ip2 > ip3
@@ -342,7 +343,7 @@ class IPv4Test < Test::Unit::TestCase
 
   def test_method_minus
     ip1 = @klass.new("10.1.1.1/8")
-    ip2 = @klass.new("10.1.1.10/8")    
+    ip2 = @klass.new("10.1.1.10/8")
     assert_equal 9, ip2 - ip1
     assert_equal 9, ip1 - ip2
   end
@@ -353,7 +354,7 @@ class IPv4Test < Test::Unit::TestCase
     assert_equal ["172.16.10.0/23"], (ip1+ip2).map{|i| i.to_string}
 
     ip2 = @klass.new("172.16.12.2/24")
-    assert_equal [ip1.network.to_string, ip2.network.to_string], 
+    assert_equal [ip1.network.to_string, ip2.network.to_string],
     (ip1 + ip2).map{|i| i.to_string}
 
     ip1 = @klass.new("10.0.0.0/23")
@@ -373,7 +374,7 @@ class IPv4Test < Test::Unit::TestCase
     assert_equal ["10.0.0.0/23","10.1.0.0/24"], (ip1+ip2).map{|i| i.to_string}
 
   end
-  
+
   def test_method_netmask_equal
     ip = @klass.new("10.1.1.1/16")
     assert_equal 16, ip.prefix.to_i
@@ -384,24 +385,24 @@ class IPv4Test < Test::Unit::TestCase
   def test_method_split
     assert_raise(ArgumentError) {@ip.split(0)}
     assert_raise(ArgumentError) {@ip.split(257)}
-    
+
     assert_equal @ip.network, @ip.split(1).first
-    
-    arr = ["172.16.10.0/27", "172.16.10.32/27", "172.16.10.64/27", 
-           "172.16.10.96/27", "172.16.10.128/27", "172.16.10.160/27", 
+
+    arr = ["172.16.10.0/27", "172.16.10.32/27", "172.16.10.64/27",
+           "172.16.10.96/27", "172.16.10.128/27", "172.16.10.160/27",
            "172.16.10.192/27", "172.16.10.224/27"]
     assert_equal arr, @network.split(8).map {|s| s.to_string}
-    arr = ["172.16.10.0/27", "172.16.10.32/27", "172.16.10.64/27", 
-           "172.16.10.96/27", "172.16.10.128/27", "172.16.10.160/27", 
+    arr = ["172.16.10.0/27", "172.16.10.32/27", "172.16.10.64/27",
+           "172.16.10.96/27", "172.16.10.128/27", "172.16.10.160/27",
            "172.16.10.192/26"]
     assert_equal arr, @network.split(7).map {|s| s.to_string}
-    arr = ["172.16.10.0/27", "172.16.10.32/27", "172.16.10.64/27", 
+    arr = ["172.16.10.0/27", "172.16.10.32/27", "172.16.10.64/27",
            "172.16.10.96/27", "172.16.10.128/26", "172.16.10.192/26"]
     assert_equal arr, @network.split(6).map {|s| s.to_string}
-    arr = ["172.16.10.0/27", "172.16.10.32/27", "172.16.10.64/27", 
+    arr = ["172.16.10.0/27", "172.16.10.32/27", "172.16.10.64/27",
            "172.16.10.96/27", "172.16.10.128/25"]
     assert_equal arr, @network.split(5).map {|s| s.to_string}
-    arr = ["172.16.10.0/26", "172.16.10.64/26", "172.16.10.128/26", 
+    arr = ["172.16.10.0/26", "172.16.10.64/26", "172.16.10.128/26",
            "172.16.10.192/26"]
     assert_equal arr, @network.split(4).map {|s| s.to_string}
     arr = ["172.16.10.0/26", "172.16.10.64/26", "172.16.10.128/25"]
@@ -416,7 +417,7 @@ class IPv4Test < Test::Unit::TestCase
     assert_raise(ArgumentError) {@network.subnet(23)}
     assert_raise(ArgumentError) {@network.subnet(33)}
     assert_nothing_raised {@ip.subnet(30)}
-    arr = ["172.16.10.0/26", "172.16.10.64/26", "172.16.10.128/26", 
+    arr = ["172.16.10.0/26", "172.16.10.64/26", "172.16.10.128/26",
            "172.16.10.192/26"]
     assert_equal arr, @network.subnet(26).map {|s| s.to_string}
     arr = ["172.16.10.0/25", "172.16.10.128/25"]
@@ -424,9 +425,9 @@ class IPv4Test < Test::Unit::TestCase
     arr = ["172.16.10.0/24"]
     assert_equal arr, @network.subnet(24).map {|s| s.to_string}
   end
-  
+
   def test_method_supernet
-    assert_raise(ArgumentError) {@ip.supernet(24)}     
+    assert_raise(ArgumentError) {@ip.supernet(24)}
     assert_equal "0.0.0.0/0", @ip.supernet(0).to_string
     assert_equal "0.0.0.0/0", @ip.supernet(-2).to_string
     assert_equal "172.16.10.0/23", @ip.supernet(23).to_string
@@ -447,7 +448,7 @@ class IPv4Test < Test::Unit::TestCase
   end
 
   def test_classmethod_summarize
-    
+
     # Should return self if only one network given
     assert_equal [@ip.network], @klass.summarize(@ip)
 
@@ -480,7 +481,7 @@ class IPv4Test < Test::Unit::TestCase
     ip2 = @klass.new("10.0.2.0/23")
     ip3 = @klass.new("10.0.4.0/24")
     ip4 = @klass.new("10.0.6.0/24")
-    assert_equal ["10.0.0.0/22","10.0.4.0/24","10.0.6.0/24"], 
+    assert_equal ["10.0.0.0/22","10.0.4.0/24","10.0.6.0/24"],
               @klass.summarize(ip1,ip2,ip3,ip4).map{|i| i.to_string}
 
     ip1 = @klass.new("10.0.1.1/24")
@@ -506,12 +507,12 @@ class IPv4Test < Test::Unit::TestCase
     ips = [@klass.new("172.16.0.0/31"),
            @klass.new("10.10.2.1/32")]
     result = ["10.10.2.1/32", "172.16.0.0/31"]
-    assert_equal result, @klass.summarize(*ips).map{|i| i.to_string}    
-           
+    assert_equal result, @klass.summarize(*ips).map{|i| i.to_string}
+
     ips = [@klass.new("172.16.0.0/32"),
            @klass.new("10.10.2.1/32")]
     result = ["10.10.2.1/32", "172.16.0.0/32"]
-    assert_equal result, @klass.summarize(*ips).map{|i| i.to_string}    
+    assert_equal result, @klass.summarize(*ips).map{|i| i.to_string}
 
   end
 
@@ -530,7 +531,7 @@ class IPv4Test < Test::Unit::TestCase
     end
     assert_raise(ArgumentError){ @klass.parse_classful("192.168.256.257") }
   end
-  
+
 end # class IPv4Test
 
-  
+

--- a/test/ipaddress/ipv6_test.rb
+++ b/test/ipaddress/ipv6_test.rb
@@ -1,11 +1,11 @@
 require 'test_helper'
- 
+
 class IPv6Test < Test::Unit::TestCase
-  
+
   def setup
     @klass = IPAddress::IPv6
-    
-    @compress_addr = {      
+
+    @compress_addr = {
       "2001:db8:0000:0000:0008:0800:200c:417a" => "2001:db8::8:800:200c:417a",
       "2001:db8:0:0:8:800:200c:417a" => "2001:db8::8:800:200c:417a",
       "ff01:0:0:0:0:0:0:101" => "ff01::101",
@@ -29,7 +29,7 @@ class IPv6Test < Test::Unit::TestCase
       "::" => 0,
       "1080:0:0:0:8:800:200C:417A" => 21932261930451111902915077091070067066,
       "1080::8:800:200C:417A" => 21932261930451111902915077091070067066}
-      
+
     @invalid_ipv6 = [":1:2:3:4:5:6:7",
                      ":1:2:3:4:5:6:7",
                      "2002:516:2:200",
@@ -39,13 +39,13 @@ class IPv6Test < Test::Unit::TestCase
       "2001:db8:1:1:1:1:1:1/32" => "2001:db8::/32",
       "2001:db8:1:1:1:1:1::/32" => "2001:db8::/32",
       "2001:db8::1/64" => "2001:db8::/64"}
-    
+
     @ip = @klass.new "2001:db8::8:800:200c:417a/64"
     @network = @klass.new "2001:db8:8:800::/64"
     @arr = [8193,3512,0,0,8,2048,8204,16762]
     @hex = "20010db80000000000080800200c417a"
   end
-  
+
   def test_attribute_address
     addr = "2001:0db8:0000:0000:0008:0800:200c:417a"
     assert_equal addr, @ip.address
@@ -56,6 +56,7 @@ class IPv6Test < Test::Unit::TestCase
     @valid_ipv6.keys.each do |ip|
       assert_nothing_raised {@klass.new ip}
     end
+    assert_raise(ArgumentError) {@klass.new nil }
     @invalid_ipv6.each do |ip|
       assert_raise(ArgumentError) {@klass.new ip}
     end
@@ -65,7 +66,7 @@ class IPv6Test < Test::Unit::TestCase
       @klass.new "::10.1.1.1"
     }
   end
-  
+
   def test_attribute_groups
     assert_equal @arr, @ip.groups
   end
@@ -74,7 +75,7 @@ class IPv6Test < Test::Unit::TestCase
     arr = "2001:0db8:0000:0000:0008:0800:200c:417a".split(":")
     assert_equal arr, @ip.hexs
   end
-  
+
   def test_method_to_i
     @valid_ipv6.each do |ip,num|
       assert_equal num, @klass.new(ip).to_i
@@ -83,7 +84,7 @@ class IPv6Test < Test::Unit::TestCase
 
   def test_method_bits
     bits = "0010000000000001000011011011100000000000000000000" +
-      "000000000000000000000000000100000001000000000000010000" + 
+      "000000000000000000000000000100000001000000000000010000" +
       "0000011000100000101111010"
     assert_equal bits, @ip.bits
   end
@@ -116,7 +117,7 @@ class IPv6Test < Test::Unit::TestCase
   def test_method_ipv4?
     assert_equal false, @ip.ipv4?
   end
-  
+
   def test_method_ipv6?
     assert_equal true, @ip.ipv6?
   end
@@ -152,7 +153,7 @@ class IPv6Test < Test::Unit::TestCase
     not_included = @klass.new "2001:db8::8:800:200c:417a/46"
     assert_equal true, @ip.include?(included)
     assert_equal false, @ip.include?(not_included)
-    # test address on same prefix 
+    # test address on same prefix
     included = @klass.new "2001:db8::8:800:200c:0/64"
     not_included = @klass.new "2001:db8:1::8:800:200c:417a/64"
     assert_equal true, @ip.include?(included)
@@ -163,11 +164,11 @@ class IPv6Test < Test::Unit::TestCase
     assert_equal true, @ip.include?(included)
     assert_equal false, @ip.include?(not_included)
   end
-  
+
   def test_method_to_hex
     assert_equal @hex, @ip.to_hex
   end
-  
+
   def test_method_to_s
     assert_equal "2001:db8::8:800:200c:417a", @ip.to_s
   end
@@ -177,10 +178,10 @@ class IPv6Test < Test::Unit::TestCase
   end
 
   def test_method_to_string_uncompressed
-    str = "2001:0db8:0000:0000:0008:0800:200c:417a/64" 
+    str = "2001:0db8:0000:0000:0008:0800:200c:417a/64"
     assert_equal str, @ip.to_string_uncompressed
   end
-  
+
   def test_method_data
     if RUBY_VERSION < "2.0"
       str = " \001\r\270\000\000\000\000\000\b\b\000 \fAz"
@@ -202,15 +203,15 @@ class IPv6Test < Test::Unit::TestCase
     assert_equal "1::1:0:0:1", @klass.new("1:0:0:0:1:0:0:1").compressed
     assert_equal "1::1", @klass.new("1:0:0:0:0:0:0:1").compressed
   end
-  
+
   def test_method_unspecified?
     assert_equal true, @klass.new("::").unspecified?
-    assert_equal false, @ip.unspecified?    
+    assert_equal false, @ip.unspecified?
   end
-  
+
   def test_method_loopback?
     assert_equal true, @klass.new("::1").loopback?
-    assert_equal false, @ip.loopback?        
+    assert_equal false, @ip.loopback?
   end
 
   def test_method_network
@@ -240,7 +241,7 @@ class IPv6Test < Test::Unit::TestCase
     # ip2 should be greater than ip1
     assert_equal true, ip2 > ip1
     assert_equal false, ip1 > ip2
-    assert_equal false, ip2 < ip1        
+    assert_equal false, ip2 < ip1
     # ip3 should be less than ip2
     assert_equal true, ip2 > ip3
     assert_equal false, ip2 < ip3
@@ -267,7 +268,7 @@ class IPv6Test < Test::Unit::TestCase
     assert_not_equal expanded, @klass.expand("2001:0db8::cd30")
     assert_not_equal expanded, @klass.expand("2001:0db8::cd3")
   end
-  
+
   def test_classmethod_compress
     compressed = "2001:db8:0:cd30::"
     expanded = "2001:0db8:0000:cd30:0000:0000:0000:0000"
@@ -298,7 +299,7 @@ class IPv6Test < Test::Unit::TestCase
 end # class IPv6Test
 
 class IPv6UnspecifiedTest < Test::Unit::TestCase
-  
+
   def setup
     @klass = IPAddress::IPv6::Unspecified
     @ip = @klass.new
@@ -327,12 +328,12 @@ class IPv6UnspecifiedTest < Test::Unit::TestCase
   def test_method_ipv6?
     assert_equal true, @ip.ipv6?
   end
-  
+
 end # class IPv6UnspecifiedTest
 
 
 class IPv6LoopbackTest < Test::Unit::TestCase
-  
+
   def setup
     @klass = IPAddress::IPv6::Loopback
     @ip = @klass.new
@@ -361,11 +362,11 @@ class IPv6LoopbackTest < Test::Unit::TestCase
   def test_method_ipv6?
     assert_equal true, @ip.ipv6?
   end
-  
+
 end # class IPv6LoopbackTest
 
 class IPv6MappedTest < Test::Unit::TestCase
-  
+
   def setup
     @klass = IPAddress::IPv6::Mapped
     @ip = @klass.new("::172.16.10.1")
@@ -424,5 +425,5 @@ class IPv6MappedTest < Test::Unit::TestCase
   def test_mapped?
     assert_equal true, @ip.mapped?
   end
-  
+
 end # class IPv6MappedTest


### PR DESCRIPTION
We end up doing a lot of calculations before actually instantiating an IPAddress object. Occasionally we end up passing a nil value which results in:

```
pry(main)> ip = IPAddress::IPv4.new(nil)
NoMethodError: undefined method `split' for nil:NilClass
```

This PR raises the same exception that is raised for invalid input when given nil input.
