### PR TITLE
Modified IPAddress::Prefix128 to allow /0 subnets

### DIFF
--- a/lib/ipaddress/prefix.rb
+++ b/lib/ipaddress/prefix.rb
@@ -214,8 +214,8 @@ module IPAddress
     #     #=> 64
     #
     def initialize(num=128)
-      unless (1..128).include? num.to_i
-        raise ArgumentError, "Prefix must be in range 1..128, got: #{num}"
+      unless (0..128).include? num.to_i
+        raise ArgumentError, "Prefix must be in range 0..128, got: #{num}"
       end
       super(num.to_i)
     end


### PR DESCRIPTION
This fix is required similar to previous fixes for Prefix32. AIX systems have loopback address set to 
inet6 ::1%1/0 with prefix of 0. This is required for Chef ohai plugins.

references to old fix: 
https://github.com/bluemonk/ipaddress/commit/af56aabfcfa46723a2ee8e71a2e706bbd230ef62 
https://github.com/bluemonk/ipaddress/commit/120a5093a115c730bb6941285f32b5b20eeb6b93
https://groups.google.com/forum/#!msg/ruby-ipaddress/wElC8J8hSrk/oUSbq3sKQCMJ
