### PR TITLE
Raise ArgumentError if IP address is nil

### DIFF
--- a/lib/ipaddress/ipv4.rb
+++ b/lib/ipaddress/ipv4.rb
@@ -61,6 +61,7 @@ module IPAddress;
     #   IPAddress::IPv4.new "10.0.0.1/255.0.0.0"
     #
     def initialize(str)
+      raise ArgumentError, "Nil IP" unless str
       ip, netmask = str.split("/")
       
       # Check the ip and remove white space

--- a/lib/ipaddress/ipv6.rb
+++ b/lib/ipaddress/ipv6.rb
@@ -87,6 +87,7 @@ module IPAddress;
     #   ip6 = IPAddress "2001:db8::8:800:200c:417a/64"
     #
     def initialize(str)
+      raise ArgumentError, "Nil IP" unless str
       ip, netmask = str.split("/")
 
       if str =~ /:.+\./

--- a/test/ipaddress/ipv4_test.rb
+++ b/test/ipaddress/ipv4_test.rb
@@ -92,6 +92,7 @@ class IPv4Test < Minitest::Test
     @invalid_ipv4.each do |i|
       assert_raises(ArgumentError) {@klass.new(i)}
     end
+    assert_raises (ArgumentError) {@klass.new(nil)}
     assert_raises (ArgumentError) {@klass.new("10.0.0.0/asd")}
   end
 

--- a/test/ipaddress/ipv6_test.rb
+++ b/test/ipaddress/ipv6_test.rb
@@ -58,6 +58,7 @@ class IPv6Test < Minitest::Test
     end
     assert_equal 64, @ip.prefix
 
+    assert_raises(ArgumentError) {@klass.new nil }
     assert_raises(ArgumentError) {
       @klass.new "::10.1.1.1"
     }


### PR DESCRIPTION
We end up doing a lot of calculations before actually instantiating an IPAddress object. Occasionally we end up passing a nil value which results in:

```
pry(main)> ip = IPAddress::IPv4.new(nil)
NoMethodError: undefined method `split' for nil:NilClass
```

This PR raises the same exception that is raised for invalid input when given nil input.
