### PR TITLE
Make eql? behare like ==.

### DIFF
--- a/lib/ipaddress/ipv4.rb
+++ b/lib/ipaddress/ipv4.rb
@@ -512,6 +512,7 @@ module IPAddress;
       return prefix <=> oth.prefix if to_u32 == oth.to_u32  
       to_u32 <=> oth.to_u32
     end
+    alias eql? ==
     
     #
     # Returns the number of IP addresses included

--- a/lib/ipaddress/ipv6.rb
+++ b/lib/ipaddress/ipv6.rb
@@ -490,6 +490,7 @@ module IPAddress;
       return prefix <=> oth.prefix if to_u128 == oth.to_u128  
       to_u128 <=> oth.to_u128
     end
+    alias eql? ==
 
     #
     # Returns the address portion of an IP in binary format,

--- a/test/ipaddress/ipv4_test.rb
+++ b/test/ipaddress/ipv4_test.rb
@@ -361,8 +361,10 @@ class IPv4Test < Minitest::Test
     assert_equal false, ip3 < ip1
     # ip1 should be equal to itself
     assert_equal true, ip1 == ip1
+    assert_equal true, ip1.eql?(ip1)
     # ip1 should be equal to ip4
     assert_equal true, ip1 == ip4
+    assert_equal true, ip1.eql?(ip4)
     # test sorting
     arr = ["10.1.1.1/8","10.1.1.1/16","172.16.1.1/14"]
     assert_equal arr, [ip1,ip2,ip3].sort.map{|s| s.to_string}

--- a/test/ipaddress/ipv6_test.rb
+++ b/test/ipaddress/ipv6_test.rb
@@ -247,6 +247,11 @@ class IPv6Test < Minitest::Test
     assert_equal false, ip3 < ip1
     # ip1 should be equal to itself
     assert_equal true, ip1 == ip1
+    assert_equal true, ip1.eql?(ip1)
+    # ip1 should be equal to a copy of itself
+    other = ip1.dup
+    assert_equal true, ip1 == other
+    assert_equal true, ip1.eql?(other)
     # ip4 should be greater than ip1
     assert_equal true, ip1 < ip4
     assert_equal false, ip1 > ip4


### PR DESCRIPTION
Quoting `Object#eql?`

> For objects of class Object, eql? is synonymous with ==. Subclasses normally continue this tradition by aliasing eql? to their overridden == method
