### PR TITLE
Adding subnet method for Ipv6 objects

### DIFF
--- a/lib/ipaddress/ipv6.rb
+++ b/lib/ipaddress/ipv6.rb
@@ -550,6 +550,38 @@ module IPAddress;
     end
 
     #
+    # This method implements the subnetting function 
+    # similar to the one described in RFC3531.
+    #
+    # By specifying a new prefix, the method calculates
+    # the network number for the given IPv6 object
+    # and calculates the subnets associated to the new
+    # prefix.
+    #
+    # For example, given the following network:
+    #
+    #   ip = IPAddress "172.16.10.0/24"
+    #
+    # we can calculate the subnets with a /26 prefix
+    #
+    #   ip.subnets(26).map{&:to_string)
+    #     #=> ["172.16.10.0/26", "172.16.10.64/26", 
+    #          "172.16.10.128/26", "172.16.10.192/26"]
+    #
+    # The resulting number of subnets will of course always be
+    # a power of two.
+    #
+
+    def subnet(subprefix)
+      unless ((@prefix.to_i)..128).include? subprefix
+        raise ArgumentError, "New prefix must be between #@prefix and 128"
+      end
+      Array.new(2**(subprefix-@prefix.to_i)) do |i|
+        self.class.parse_u128(network_u128+(i*(2**(128-subprefix))), subprefix)
+      end
+    end
+
+    #
     # Extract 16 bits groups from a string
     #
     def self.groups(str)

--- a/lib/ipaddress/ipv6.rb
+++ b/lib/ipaddress/ipv6.rb
@@ -560,13 +560,13 @@ module IPAddress;
     #
     # For example, given the following network:
     #
-    #   ip = IPAddress "172.16.10.0/24"
+    #   ip = IPAddress "2001:db8:8:800::/64"
     #
-    # we can calculate the subnets with a /26 prefix
+    # we can calculate the subnets with a /66 prefix
     #
-    #   ip.subnets(26).map{&:to_string)
-    #     #=> ["172.16.10.0/26", "172.16.10.64/26", 
-    #          "172.16.10.128/26", "172.16.10.192/26"]
+    #   ip.subnets(66).map{&:to_string)
+    #     #=> ["2001:db8:8:800::/66", "2001:db8:8:800:4000::/66", "2001:db8:8:800:8000::/66", 
+    #      "2001:db8:8:800:c000::/66"]
     #
     # The resulting number of subnets will of course always be
     # a power of two.

--- a/test/ipaddress/ipv6_test.rb
+++ b/test/ipaddress/ipv6_test.rb
@@ -142,6 +142,18 @@ class IPv6Test < Minitest::Test
     assert_equal 2**4, ip.size
   end
 
+  def test_method_subnet
+    assert_raises(ArgumentError) {@network.subnet(62)}
+    assert_raises(ArgumentError) {@network.subnet(129)}
+    arr = ["172.16.10.0/26", "172.16.10.64/26", "172.16.10.128/26", 
+           "172.16.10.192/26"]
+    assert_equal arr, @network.subnet(26).map {|s| s.to_string}
+    arr = ["172.16.10.0/25", "172.16.10.128/25"]
+    assert_equal arr, @network.subnet(25).map {|s| s.to_string}
+    arr = ["172.16.10.0/24"]
+    assert_equal arr, @network.subnet(24).map {|s| s.to_string}
+  end
+
   def test_method_include?
     assert_equal true, @ip.include?(@ip)
     # test prefix on same address

--- a/test/ipaddress/ipv6_test.rb
+++ b/test/ipaddress/ipv6_test.rb
@@ -145,10 +145,10 @@ class IPv6Test < Minitest::Test
   def test_method_subnet
     assert_raises(ArgumentError) {@network.subnet(62)}
     assert_raises(ArgumentError) {@network.subnet(129)}
-    arr = ["2001:db8:8:800::/66", "2001:db8:8:800:4000:/66", "2001:db8:8:800:8000:/66", 
-           "2001:db8:8:800:c000:/66"]
+    arr = ["2001:db8:8:800::/66", "2001:db8:8:800:4000::/66", "2001:db8:8:800:8000::/66", 
+           "2001:db8:8:800:c000::/66"]
     assert_equal arr, @network.subnet(66).map {|s| s.to_string}
-    arr = ["2001:db8:8:800::/65", "2001:db8:8:800:8000:/65"]
+    arr = ["2001:db8:8:800::/65", "2001:db8:8:800:8000::/65"]
     assert_equal arr, @network.subnet(65).map {|s| s.to_string}
     arr = ["2001:db8:8:800::/64"]
     assert_equal arr, @network.subnet(64).map {|s| s.to_string}

--- a/test/ipaddress/ipv6_test.rb
+++ b/test/ipaddress/ipv6_test.rb
@@ -141,17 +141,17 @@ class IPv6Test < Minitest::Test
     ip = @klass.new("2001:db8::8:800:200c:417a/124")
     assert_equal 2**4, ip.size
   end
-
+####Fill out proper ipv6 values... not sure how to do that math by hand yet.
   def test_method_subnet
     assert_raises(ArgumentError) {@network.subnet(62)}
     assert_raises(ArgumentError) {@network.subnet(129)}
-    arr = ["172.16.10.0/26", "172.16.10.64/26", "172.16.10.128/26", 
-           "172.16.10.192/26"]
-    assert_equal arr, @network.subnet(26).map {|s| s.to_string}
-    arr = ["172.16.10.0/25", "172.16.10.128/25"]
-    assert_equal arr, @network.subnet(25).map {|s| s.to_string}
-    arr = ["172.16.10.0/24"]
-    assert_equal arr, @network.subnet(24).map {|s| s.to_string}
+    arr = ["2001:db8:8:800::/66", "2001:db8:8:800:4000:/66", "2001:db8:8:800:8000:/66", 
+           "2001:db8:8:800:c000:/66"]
+    assert_equal arr, @network.subnet(66).map {|s| s.to_string}
+    arr = ["2001:db8:8:800::/65", "2001:db8:8:800:8000:/65"]
+    assert_equal arr, @network.subnet(65).map {|s| s.to_string}
+    arr = ["2001:db8:8:800::/64"]
+    assert_equal arr, @network.subnet(64).map {|s| s.to_string}
   end
 
   def test_method_include?


### PR DESCRIPTION
Added support for ipv6 subnetting. Seems all the pieces to do it were already written, so I really just wrote the test and switched out the pieces of the ipv4 subnetting code for ipv6. I was expecting to have to write more code, so I'm wondering if maybe not including IPV6 subnetting is intentional?

