### PR TITLE
Add detection of link-local addresses

### DIFF
--- a/lib/ipaddress/ipv4.rb
+++ b/lib/ipaddress/ipv4.rb
@@ -649,6 +649,20 @@ module IPAddress;
     end
 
     #
+    # Checks if an IPv4 address objects belongs
+    # to a link-local network RFC3927
+    #
+    # Example:
+    #
+    #   ip = IPAddress "169.254.0.1"
+    #   ip.link_local?
+    #     #=> true
+    #
+    def link_local?
+      [self.class.new("169.254.0.0/16")].any? {|i| i.include? self}
+    end
+
+    #
     # Returns the IP address in in-addr.arpa format
     # for DNS lookups
     #

--- a/lib/ipaddress/ipv6.rb
+++ b/lib/ipaddress/ipv6.rb
@@ -423,7 +423,7 @@ module IPAddress;
     end
 
     #
-    # Checks if an IPv4 address objects belongs
+    # Checks if an IPv6 address objects belongs
     # to a link-local network RFC4291
     #
     # Example:

--- a/lib/ipaddress/ipv6.rb
+++ b/lib/ipaddress/ipv6.rb
@@ -436,6 +436,20 @@ module IPAddress;
       [self.class.new("fe80::/64")].any? {|i| i.include? self}
     end
 
+    #
+    # Checks if an IPv6 address objects belongs
+    # to a unique-local network RFC4193
+    #
+    # Example:
+    #
+    #   ip = IPAddress "fc00::1"
+    #   ip.unique_local?
+    #     #=> true
+    #
+    def unique_local?
+      [self.class.new("fc00::/7")].any? {|i| i.include? self}
+    end
+
     # 
     # Returns true if the address is a mapped address
     # 

--- a/lib/ipaddress/ipv6.rb
+++ b/lib/ipaddress/ipv6.rb
@@ -422,6 +422,20 @@ module IPAddress;
       @prefix == 128 and @compressed == "::1"
     end
 
+    #
+    # Checks if an IPv4 address objects belongs
+    # to a link-local network RFC4291
+    #
+    # Example:
+    #
+    #   ip = IPAddress "fe80::1"
+    #   ip.link_local?
+    #     #=> true
+    #
+    def link_local?
+      [self.class.new("fe80::/64")].any? {|i| i.include? self}
+    end
+
     # 
     # Returns true if the address is a mapped address
     # 

--- a/test/ipaddress/ipv4_test.rb
+++ b/test/ipaddress/ipv4_test.rb
@@ -74,6 +74,22 @@ class IPv4Test < Minitest::Test
       "10.32.0.1" => ["10.32.0.253", 253],
       "192.0.0.0" => ["192.1.255.255", 131072]
     }
+
+    @link_local = [
+      "169.254.0.0",
+      "169.254.255.255",
+      "169.254.12.34",
+      "169.254.0.0/16",
+      "169.254.0.0/17"]
+    
+    @not_link_local = [
+      "127.0.0.1",
+      "127.0.1.1",
+      "192.168.0.100",
+      "169.255.0.0",
+      "169.254.0.0/15",
+      "0.0.0.0",
+      "255.255.255.255"]
     
   end
 
@@ -307,6 +323,15 @@ class IPv4Test < Minitest::Test
     assert_equal false, @klass.new("172.32.0.0/12").private?
     assert_equal false, @klass.new("172.16.0.0/11").private?
     assert_equal false, @klass.new("192.0.0.2/24").private?
+  end
+
+  def test_method_link_local?
+    @link_local.each do |addr|
+      assert_equal true, @klass.new(addr).link_local?
+    end
+    @not_link_local.each do |addr|
+      assert_equal false, @klass.new(addr).link_local?
+    end
   end
 
   def test_method_octet

--- a/test/ipaddress/ipv6_test.rb
+++ b/test/ipaddress/ipv6_test.rb
@@ -58,6 +58,22 @@ class IPv6Test < Minitest::Test
       "ff80:03:02:01::",
       "2001:db8::8:800:200c:417a",
       "fe80::/63"]
+
+    @unique_local = [
+      "fc00::/7",
+      "fc00::/8",
+      "fd00::/8",
+      "fd12:3456:789a:1::1",
+      "fd12:3456:789a:1::/64",
+      "fc00::1"]
+
+    @not_unique_local = [
+      "fc00::/6",
+      "::",
+      "::1",
+      "fe80::",
+      "fe80::1",
+      "fe80::/64"]
     
   end
   
@@ -237,6 +253,15 @@ class IPv6Test < Minitest::Test
     end
     @not_link_local.each do |addr|
       assert_equal false, @klass.new(addr).link_local?
+    end
+  end
+
+  def test_method_unique_local?
+    @unique_local.each do |addr|
+      assert_equal true, @klass.new(addr).unique_local?
+    end
+    @not_unique_local.each do |addr|
+      assert_equal false, @klass.new(addr).unique_local?
     end
   end
 

--- a/test/ipaddress/ipv6_test.rb
+++ b/test/ipaddress/ipv6_test.rb
@@ -44,6 +44,21 @@ class IPv6Test < Minitest::Test
     @network = @klass.new "2001:db8:8:800::/64"
     @arr = [8193,3512,0,0,8,2048,8204,16762]
     @hex = "20010db80000000000080800200c417a"
+
+    @link_local = [
+      "fe80::",
+      "fe80::1",
+      "fe80::208:74ff:feda:625c",
+      "fe80::/64",
+      "fe80::/65"]
+    
+    @not_link_local = [
+      "::",
+      "::1",
+      "ff80:03:02:01::",
+      "2001:db8::8:800:200c:417a",
+      "fe80::/63"]
+    
   end
   
   def test_attribute_address
@@ -214,6 +229,15 @@ class IPv6Test < Minitest::Test
   def test_method_loopback?
     assert_equal true, @klass.new("::1").loopback?
     assert_equal false, @ip.loopback?        
+  end
+
+  def test_method_link_local?
+    @link_local.each do |addr|
+      assert_equal true, @klass.new(addr).link_local?
+    end
+    @not_link_local.each do |addr|
+      assert_equal false, @klass.new(addr).link_local?
+    end
   end
 
   def test_method_network


### PR DESCRIPTION
Added a method to IPv4 and IPv6 classes `#link_local?`. It simply checks if an address is considered a link-local address by RFC3927 (IPv4) and RFC4291 (IPv6).