### PR TITLE
Integer Unification for Ruby 2.4.0+

### DIFF
--- a/lib/ipaddress/prefix.rb
+++ b/lib/ipaddress/prefix.rb
@@ -55,10 +55,10 @@ module IPAddress
 
     #
     # Sums two prefixes or a prefix to a 
-    # number, returns a Fixnum
+    # number, returns a Integer
     #
     def +(oth)
-      if oth.is_a? Fixnum
+      if oth.is_a? Integer
         self.prefix + oth
       else
         self.prefix + oth.prefix
@@ -68,10 +68,10 @@ module IPAddress
     #
     # Returns the difference between two
     # prefixes, or a prefix and a number,
-    # as a Fixnum
+    # as a Integer
     #
     def -(oth)
-      if oth.is_a? Fixnum
+      if oth.is_a? Integer
         self.prefix - oth
       else
         (self.prefix - oth.prefix).abs


### PR DESCRIPTION
Ruby 2.4.0 unifies Fixnum and Bignum into Integer.

https://bugs.ruby-lang.org/issues/12005

Fix following deprecated warnings in Ruby 2.4.0-preview3.

`warning: constant ::Fixnum is deprecated`

Thanks.