### PR TITLE
Add == methods for IPv4 and IPv6

### DIFF
--- a/lib/ipaddress/ipv4.rb
+++ b/lib/ipaddress/ipv4.rb
@@ -476,6 +476,13 @@ module IPAddress;
       end
     end
 
+    # Equality operator
+    def ==(oth)
+      oth.class == self.class && \
+        oth.to_u32 == self.to_u32 && \
+        oth.prefix == self.prefix
+    end
+
     #
     # Spaceship operator to compare IPv4 objects
     #

--- a/lib/ipaddress/ipv6.rb
+++ b/lib/ipaddress/ipv6.rb
@@ -454,6 +454,13 @@ module IPAddress;
       end
     end
 
+    # Equality operator
+    def ==(oth)
+      oth.class == self.class && \
+        oth.prefix == self.prefix && \
+        oth.to_u128 == self.to_u128
+    end
+
     #
     # Spaceship operator to compare IPv6 objects
     #

--- a/test/ipaddress/ipv4_test.rb
+++ b/test/ipaddress/ipv4_test.rb
@@ -363,6 +363,10 @@ class IPv4Test < Minitest::Test
     assert_equal true, ip1 == ip1
     # ip1 should be equal to ip4
     assert_equal true, ip1 == ip4
+    # ip1 should be unequal to ip2
+    assert_equal false, ip1 == ip2
+    # ip1 should be unequal to nil
+    assert_equal false, ip1 == nil
     # test sorting
     arr = ["10.1.1.1/8","10.1.1.1/16","172.16.1.1/14"]
     assert_equal arr, [ip1,ip2,ip3].sort.map{|s| s.to_string}

--- a/test/ipaddress/ipv6_test.rb
+++ b/test/ipaddress/ipv6_test.rb
@@ -250,6 +250,10 @@ class IPv6Test < Minitest::Test
     # ip4 should be greater than ip1
     assert_equal true, ip1 < ip4
     assert_equal false, ip1 > ip4
+    # ip1 should be unequal to ip2
+    assert_equal false, ip1 == ip2
+    # ip1 should be unequal to nil
+    assert_equal false, ip1 == nil
     # test sorting
     arr = ["2001:db8:1::1/64","2001:db8:1::1/65",
            "2001:db8:1::2/64","2001:db8:2::1/64"]


### PR DESCRIPTION
ActiveRecord requires these methods for seriaization.  <=> is
insufficient