### PR TITLE
Update CodeClimate syntax for 1.0.0 compatibility

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 require 'minitest/autorun'
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+require 'simplecov'
+SimpleCov.start
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))


### PR DESCRIPTION
Unbreak the tests due to changes in Code Climate's service.  A separate change will be necessary to fix submitting results.