### PR TITLE
Don't create a new object every time `IPv6::include?` is called

### DIFF
--- a/lib/ipaddress/ipv6.rb
+++ b/lib/ipaddress/ipv6.rb
@@ -384,7 +384,7 @@ module IPAddress;
     #     #=> false
     #
     def include?(oth)
-      @prefix <= oth.prefix and network_u128 == self.class.new(oth.address+"/#@prefix").network_u128
+      @prefix <= oth.prefix and network_u128 == (oth.to_u128 & @prefix.to_u128)
     end
 
     #


### PR DESCRIPTION
Was writing code that relied heavily on `include?` for both IPv4 and IPv6 addresses and noticed a x30-40 slowdown comparing IPv6 addresses versus IPv4 addresses. Looking at the library it's clear that this slowdown is because each `include?` creates a new IPAddress::IPv6 object which is not the case for IPv4 addresses. Ran the test pack and came back clean.