### PR TITLE
Fix comparison by using internal fields - address and prefix

### DIFF
--- a/lib/ipaddress/ipv4.rb
+++ b/lib/ipaddress/ipv4.rb
@@ -515,6 +515,23 @@ module IPAddress;
       return prefix <=> oth.prefix if to_u32 == oth.to_u32  
       to_u32 <=> oth.to_u32
     end
+
+    #
+    # Check if 2 IPs (ranges) are equal
+    #
+    # Example:
+    #
+    #   ip1 = IPAddress '10.0.0.0/24'
+    #   ip2 = IPAddress '10.0.0.0/24'
+    #   ip3 = IPAddress '10.0.0.0/25'
+    #
+    #   ip1.eql? ip2 # => true
+    #   ip2.eql? ip1 # => true
+    #   ip1.eql? ip3 # => false
+    def eql?(other)
+      (!other.is_a? self.class) || (prefix == other.prefix && to_u32 == other.to_u32)
+    end
+
     alias eql? ==
     
     #

--- a/lib/ipaddress/ipv6.rb
+++ b/lib/ipaddress/ipv6.rb
@@ -525,9 +525,27 @@ module IPAddress;
     #
     def <=>(oth)
       return nil unless oth.is_a?(self.class)
-      return prefix <=> oth.prefix if to_u128 == oth.to_u128  
+      return prefix <=> oth.prefix if to_u128 == oth.to_u128
       to_u128 <=> oth.to_u128
     end
+
+    # Check if 2 IPs (ranges) are equal
+    #
+    # Example:
+    #
+    #   ip1 = IPAddress "2001:db8:1::1/64"
+    #   ip2 = IPAddress "2001:db8:1::1/64"
+    #   ip3 = IPAddress "2001:db8:1::1/65"
+    #   ip4 = IPAddress "2001:db8:2::1/65"
+    #
+    #   ip1.eql? ip2 # => true
+    #   ip2.eql? ip1 # => true
+    #   ip1.eql? ip3 # => false
+    #   ip4.eql? ip3 # => false
+    def eql?(other)
+      (!other.is_a? self.class) || (prefix == other.prefix && to_u128 == oth.to_u128)
+    end
+
     alias eql? ==
 
     #


### PR DESCRIPTION
Now `IPAddress('192.168.0.0/24').eql? IPAddress('192.168.0.0/24')` returns false.
This patch adds a proper comparison.

Also, patch supposed to fix `uniq` method on `Array<IPAddress>`, but it apparently doesn't...