### PR TITLE
Add method to substract IPv4 subnets

### DIFF
--- a/lib/ipaddress/ipv4.rb
+++ b/lib/ipaddress/ipv4.rb
@@ -807,36 +807,38 @@ module IPAddress;
 
     #
     # Subtract other from the current range
-    # Returns list of ranges that excludes :other
+    # Result is a list of ranges that are all a part of the current range
+    # excluding the other range
     #
     # Example:
     #
-    #   a = IPAddress '10.0.0.0/16'
-    #   b = IPAddress '10.0.128.0/18'
-    #   c = IPAddress '192.168.0.0/16'
+    #   whole_range = IPAddress '10.0.0.0/16'
+    #   sub_range = IPAddress '10.0.128.0/18'
+    #   non_overlap_range = IPAddress '192.168.0.0/16'
     #
-    #   a.subtract(b)
-    #   => 
+    #   whole_range.subtract(sub_range)
+    #   =>
     #   [#<IPAddress::IPv4:0x0000000111e61a88 @address="10.0.0.0", @allocator=0, @octets=[10, 0, 0, 0], @prefix=18, @u32=167772160>,
     #    #<IPAddress::IPv4:0x0000000111e61470 @address="10.0.64.0", @allocator=0, @octets=[10, 0, 64, 0], @prefix=18, @u32=167788544>,
-    #    #<IPAddress::IPv4:0x0000000111e60840 @address="10.0.192.0", @allocator=0, @octets=[10, 0, 192, 0], @prefix=18, @u32=167821312>] 
-    #   b.subtract(a)
+    #    #<IPAddress::IPv4:0x0000000111e60840 @address="10.0.192.0", @allocator=0, @octets=[10, 0, 192, 0], @prefix=18, @u32=167821312>]
+    #   sub_range.subtract(whole_range)
     #    => []
-    #   a.subtract(c)
-    #    => [#<IPAddress::IPv4:0x0000000107f08978 @address="10.0.0.0", @allocator=0, @octets=[10, 0, 0, 0], @prefix=16, @u32=167772160>] 
+    #   whole_range.subtract(non_overlap_range)
+    #    => [#<IPAddress::IPv4:0x0000000107f08978 @address="10.0.0.0", @allocator=0, @octets=[10, 0, 0, 0], @prefix=16, @u32=167772160>]
     #
     def subtract(other)
       raise ArgumentError unless other.is_a? self.class
+
       result = []
-      if self.include? other
-        split_bits = 2**(self.prefix - other.prefix)
-        other_alike_subnets = self.split split_bits
+      if include? other
+        split_bits = 2**(prefix - other.prefix)
+        other_alike_subnets = split split_bits
         raise "Prefix of subnet and split doesn't match" unless other_alike_subnets.first.prefix == other.prefix
-    
+
         other_alike_subnets.delete other
         result = other_alike_subnets
       elsif !other.include? self
-        result << self.clone
+        result << clone
       end
       result
     end

--- a/test/ipaddress/ipv4_test.rb
+++ b/test/ipaddress/ipv4_test.rb
@@ -491,6 +491,16 @@ class IPv4Test < Minitest::Test
     arr = ["172.16.10.0/24"]
     assert_equal arr, @network.subnet(24).map {|s| s.to_string}
   end
+
+  def test_method_subtract
+    a = IPAddress '10.0.0.0/16'
+    b = IPAddress '10.0.128.0/18'
+    c = IPAddress '192.168.0.0/16'
+
+    assert !a.subtract(b).include?(b)
+    assert b.subtract(a).empty?
+    assert_equal a, a.subtract(c).first
+  end
   
   def test_method_supernet
     assert_raises(ArgumentError) {@ip.supernet(24)}     

--- a/test/ipaddress/ipv4_test.rb
+++ b/test/ipaddress/ipv4_test.rb
@@ -492,14 +492,30 @@ class IPv4Test < Minitest::Test
     assert_equal arr, @network.subnet(24).map {|s| s.to_string}
   end
 
-  def test_method_subtract
-    a = IPAddress '10.0.0.0/16'
-    b = IPAddress '10.0.128.0/18'
-    c = IPAddress '192.168.0.0/16'
+  def test_method_subtract_result_not_include_subtrahend
+    whole_range = IPAddress '10.0.0.0/16'
+    sub_range = IPAddress '10.0.128.0/18'
+    assert !whole_range.subtract(sub_range).include?(sub_range)
+  end
 
-    assert !a.subtract(b).include?(b)
-    assert b.subtract(a).empty?
-    assert_equal a, a.subtract(c).first
+  def test_method_subtract_empty_result_if_subtract_whole
+    whole_range = IPAddress '10.0.0.0/16'
+    sub_range = IPAddress '10.0.128.0/18'
+    assert sub_range.subtract(whole_range).empty?
+  end
+
+  def test_method_subtract_non_overlap_range
+    whole_range = IPAddress '10.0.0.0/16'
+    non_overlap_range = IPAddress '192.168.0.0/16'
+    assert_equal 1, whole_range.subtract(non_overlap_range).size
+    assert_equal whole_range, whole_range.subtract(non_overlap_range).first
+  end
+
+  def test_method_subtract_inividual_address
+    whole_range = IPAddress '10.0.0.0/26'
+    one_ip_address = IPAddress '10.0.0.26'
+    assert_equal 2**(32 - 26) - 1, whole_range.subtract(one_ip_address).size
+    assert !whole_range.subtract(one_ip_address).include?(one_ip_address)
   end
   
   def test_method_supernet


### PR DESCRIPTION
Subnets substraction is useful to e.g. calculate GCP internal API address pool using [this](https://support.google.com/a/answer/10026322?hl=en) guide.