### PR TITLE
Replace assert_equal nil with assert_nil in tests

### DIFF
--- a/test/ipaddress/ipv4_test.rb
+++ b/test/ipaddress/ipv4_test.rb
@@ -404,8 +404,8 @@ class IPv4Test < Minitest::Test
     ip1 = @klass.new('127.0.0.1')
     ip2 = IPAddress::IPv6.new('::1')
     not_ip = String
-    assert_equal nil, ip1 <=> ip2
-    assert_equal nil, ip1 <=> not_ip
+    assert_nil ip1 <=> ip2
+    assert_nil ip1 <=> not_ip
   end
 
   def test_method_minus

--- a/test/ipaddress/ipv6_test.rb
+++ b/test/ipaddress/ipv6_test.rb
@@ -341,8 +341,8 @@ class IPv6Test < Minitest::Test
     ip1 = @klass.new('::1')
     ip2 = IPAddress::IPv4.new('127.0.0.1')
     not_ip = String
-    assert_equal nil, ip1 <=> ip2
-    assert_equal nil, ip1 <=> not_ip
+    assert_nil ip1 <=> ip2
+    assert_nil ip1 <=> not_ip
   end
 
   def test_classmethod_expand


### PR DESCRIPTION
Fix messages like:

```
DEPRECATED: Use assert_nil if expecting nil from .../ipv6_test.rb:344. This will fail in Minitest 6.
```